### PR TITLE
fix: 调整JAB方法的Y轴偏移计算

### DIFF
--- a/src/InputTip.JAB.JetBrains.ahk
+++ b/src/InputTip.JAB.JetBrains.ahk
@@ -75,13 +75,13 @@ GetCaretPosFromJAB(&X?, &Y?, &W?, &H?) {
         prevThreadDpiAwarenessContext := DllCall("SetThreadDpiAwarenessContext", "ptr", -2, "ptr")
         DllCall(JAB.module "\getAccessibleContextWithFocus", "ptr", hWnd, "Int*", &vmID := 0, JAB.acType "*", &ac := 0, "Cdecl Int") "`n"
         DllCall(JAB.module "\getCaretLocation", "Int", vmID, JAB.acType, ac, "Ptr", Info := Buffer(16, 0), "Int", 0, "Cdecl Int")
-        DllCall(JAB.module "\releaseJavaObject", "Int", vmId, JAB.acType, ac, "CDecl")
+        DllCall(JAB.module "\releaseJavaObject", "Int", vmID, JAB.acType, ac, "CDecl")
         DllCall("SetThreadDpiAwarenessContext", "ptr", prevThreadDpiAwarenessContext, "ptr")
         X := NumGet(Info, 0, "Int"), Y := NumGet(Info, 4, "Int"), W := NumGet(Info, 8, "Int"), H := NumGet(Info, 12, "Int")
         hMonitor := DllCall("MonitorFromWindow", "ptr", hWnd, "int", 2, "ptr") ; MONITOR_DEFAULTTONEAREST
         DllCall("Shcore.dll\GetDpiForMonitor", "ptr", hMonitor, "int", 0, "uint*", &dpiX := 0, "uint*", &dpiY := 0)
         if dpiX
-            X := DllCall("MulDiv", "int", X, "int", dpiX, "int", 96, "int"), Y := DllCall("MulDiv", "int", Y, "int", dpiX, "int", 96, "int")
+            X := DllCall("MulDiv", "int", X, "int", dpiX, "int", 96, "int"), Y := DllCall("MulDiv", "int", Y, "int", dpiX, "int", 96, "int"), W := DllCall("MulDiv", "int", W, "int", dpiX, "int", 96, "int"), H := DllCall("MulDiv", "int", H, "int", dpiX, "int", 96, "int")
         if X || Y || W || H
             return
     }

--- a/src/utils/var.ahk
+++ b/src/utils/var.ahk
@@ -529,7 +529,7 @@ loadSymbol(state, left, top, right, bottom, isShowCursorPos := 0) {
     ; JAB 程序通过 GetCaretPosFromJAB 获取到的 W 和 H 非常不稳定
     ; 还是继续使用 top，根据实际情况再调整特殊偏移量
     if (InStr(modeList.JAB, exe_str)) {
-        offsetY := top
+        offsetY := top + bottom
     } else {
         offsetY := symbolOffsetBase ? bottom : top
     }


### PR DESCRIPTION
W 和 H 未做 DPI 缩放，不知是不是导致Jetbrains IDE中W H不稳定的原因；
bottom是表示bounding rectangle height，`offsetY := top + bottom`应该能更好地表示底部初始位置