### PR TITLE
feat: add window disable hook for plugin integrations

### DIFF
--- a/src/InputTip.ahk
+++ b/src/InputTip.ahk
@@ -49,27 +49,27 @@ checkUpdate(1)
 
 if (hotkey_CN) {
     try {
-        Hotkey(hotkey_CN, switch_CN)
+        Hotkey(hotkey_CN, __InputTip_switch_CN)
     }
 }
 if (hotkey_EN) {
     try {
-        Hotkey(hotkey_EN, switch_EN)
+        Hotkey(hotkey_EN, __InputTip_switch_EN)
     }
 }
 if (hotkey_Caps) {
     try {
-        Hotkey(hotkey_Caps, switch_Caps)
+        Hotkey(hotkey_Caps, __InputTip_switch_Caps)
     }
 }
 if (hotkey_Pause) {
     try {
-        Hotkey(hotkey_Pause, pauseApp)
+        Hotkey(hotkey_Pause, __InputTip_pauseApp)
     }
 }
 if (hotkey_ShowCode) {
     try {
-        Hotkey(hotkey_ShowCode, showCode)
+        Hotkey(hotkey_ShowCode, __InputTip_showCode)
     }
 }
 
@@ -140,6 +140,58 @@ getPathList() {
 
 makeTrayMenu() ; 生成托盘菜单
 
+global IT_WINDOW_DISABLE_FLAG := A_ScriptDir "\plugins\window_disable.flag"
+global IT_WINDOW_DISABLED := false
+
+SetTimer(__InputTip_SyncWindowDisableState, 100)
+
+__InputTip_SyncWindowDisableState() {
+    global IT_WINDOW_DISABLE_FLAG
+    global IT_WINDOW_DISABLED
+
+    IT_WINDOW_DISABLED := !!FileExist(IT_WINDOW_DISABLE_FLAG)
+}
+
+__InputTip_IsWindowDisabled() {
+    global IT_WINDOW_DISABLED
+    return IT_WINDOW_DISABLED
+}
+
+__InputTip_switch_CN(*) {
+    if (__InputTip_IsWindowDisabled()) {
+        return
+    }
+    switch_CN()
+}
+
+__InputTip_switch_EN(*) {
+    if (__InputTip_IsWindowDisabled()) {
+        return
+    }
+    switch_EN()
+}
+
+__InputTip_switch_Caps(*) {
+    if (__InputTip_IsWindowDisabled()) {
+        return
+    }
+    switch_Caps()
+}
+
+__InputTip_pauseApp(*) {
+    if (__InputTip_IsWindowDisabled()) {
+        return
+    }
+    pauseApp()
+}
+
+__InputTip_showCode(*) {
+    if (__InputTip_IsWindowDisabled()) {
+        return
+    }
+    showCode()
+}
+
 
 /**
  * 跳过 JAB/JetBrains IDE 程序，交由 InputTip.JAB 处理
@@ -147,10 +199,18 @@ makeTrayMenu() ; 生成托盘菜单
  * @returns {1 | 0} 是否需要跳过
  */
 needSkip(exe_str) {
+    if (__InputTip_IsWindowDisabled()) {
+        return 1
+    }
     return !showCursorPos && InStr(modeList.JAB, exe_str)
 }
 
 returnCanShowSymbol(&left, &top, &right, &bottom) {
+    if (__InputTip_IsWindowDisabled()) {
+        left := 0, top := 0, right := 0, bottom := 0
+        return 0
+    }
+
     res := 0
 
     try {

--- a/src/menu/tray-menu.ahk
+++ b/src/menu/tray-menu.ahk
@@ -719,6 +719,11 @@ showCode(*) {
             return
         }
 
+        if (__InputTip_IsWindowDisabled()) {
+            ToolTip()
+            return
+        }
+
         info := IME.CheckInputMode()
         ToolTip("状态码: " info.statusMode "`n切换码: " info.conversionMode)
     }

--- a/src/utils/show.ahk
+++ b/src/utils/show.ahk
@@ -8,6 +8,7 @@ hasWindowChange := 1
 
 lastInputState := ""
 inputStateChanged := 0
+lastWindowDisabled := 0
 
 loop {
     Sleep(delay)
@@ -19,6 +20,25 @@ loop {
             exe_name := ProcessGetName(WinGetPID("A"))
             exe_title := WinGetTitle("A")
             exe_str := ":" exe_name ":"
+
+            if (__InputTip_IsWindowDisabled()) {
+                if (!lastWindowDisabled) {
+                    hideSymbol()
+                    if (changeCursor) {
+                        revertCursor(cursorInfo)
+                    }
+                    lastSymbol := ""
+                    lastCursor := ""
+                    lastWindow := ""
+                }
+                lastWindowDisabled := 1
+                continue
+            }
+
+            if (lastWindowDisabled) {
+                lastWindowDisabled := 0
+                hasWindowChange := 1
+            }
 
             if (symbolType && needSkip(exe_str)) {
                 hideSymbol()


### PR DESCRIPTION
## 目标行为

- 当焦点进入某个指定窗口时，例如 `mstsc.exe`
- InputTip 不再介入工作
- 不自动切换输入法
- 不显示符号提示
- 不响应相关快捷键
- 当焦点回到其他普通窗口时自动恢复
- 整个过程不退出进程，不依赖暂停热键

这和现有“指定窗口自动退出”不同。这里需要的是逻辑禁用，不是结束进程。

## 为什么不用 `pauseApp()` 或外部热键

直接调用 `pauseApp()` 会把负责“检测何时恢复”的计时器一起暂停，脚本能停下但不能自动恢复。

改成外部 helper 发送暂停热键，在 `mstsc.exe` 这类窗口里又容易被目标程序吞掉，结果通常是进入时没停，切回本地时反而误触发一次切换。

所以，上游更适合接受的方案不是“暂停脚本”，而是“让核心逻辑在特定窗口中主动跳过工作”。

## 仓库里的职责拆分

核心代码涉及这些文件：

```text
src/InputTip.ahk
src/utils/show.ahk
src/menu/tray-menu.ahk
```

如果你要给出一个可运行示例，再额外使用：

```text
src/plugins/InputTip.plugin.ahk
```

核心约定很简单：

- 如果 `src/plugins/window_disable.flag` 存在，则当前处于“逻辑禁用”状态
- 主仓库只识别这个状态，不内置任何 `mstsc.exe` 之类的特定规则
- 插件负责决定何时创建或删除这个标记文件

## 插件示例：负责生成禁用标记

文件路径：

```text
src/plugins/InputTip.plugin.ahk
```

参考实现：

```ahk
; InputTip
#Requires AutoHotkey v2.0

global IT_DISABLE_EXE := "mstsc.exe"
global IT_DISABLE_TITLE_REGEX := ""
global IT_DISABLE_CHECK_MS := 300
global IT_DISABLE_FLAG := A_ScriptDir "\plugins\window_disable.flag"

global __it_last_disabled := false

SetTimer(__InputTip_WindowDisableWatcher, IT_DISABLE_CHECK_MS)

__InputTip_WindowDisableWatcher() {
    global IT_DISABLE_EXE
    global IT_DISABLE_TITLE_REGEX
    global IT_DISABLE_FLAG
    global __it_last_disabled

    hwnd := WinExist("A")
    if !hwnd {
        return
    }

    exe := ""
    title := ""

    try exe := WinGetProcessName(hwnd)
    catch
        return

    try title := WinGetTitle(hwnd)
    catch
        title := ""

    matched := false

    if (StrLower(exe) = StrLower(IT_DISABLE_EXE)) {
        if (IT_DISABLE_TITLE_REGEX = "") {
            matched := true
        } else {
            matched := !!RegExMatch(title, IT_DISABLE_TITLE_REGEX)
        }
    }

    if (matched = __it_last_disabled) {
        return
    }

    if (matched) {
        try FileDelete(IT_DISABLE_FLAG)
        FileAppend("1", IT_DISABLE_FLAG, "UTF-8")
    } else {
        try FileDelete(IT_DISABLE_FLAG)
    }

    __it_last_disabled := matched
}

OnExit(__InputTip_CleanupDisableFlag)

__InputTip_CleanupDisableFlag(*) {
    global IT_DISABLE_FLAG
    try FileDelete(IT_DISABLE_FLAG)
}
```

## 主仓库改动一：同步禁用状态

文件：

```text
src/InputTip.ahk
```

在 `makeTrayMenu()` 之后加入通用状态同步：

```ahk
global IT_WINDOW_DISABLE_FLAG := A_ScriptDir "\plugins\window_disable.flag"
global IT_WINDOW_DISABLED := false

SetTimer(__InputTip_SyncWindowDisableState, 100)

__InputTip_SyncWindowDisableState() {
    global IT_WINDOW_DISABLE_FLAG
    global IT_WINDOW_DISABLED

    IT_WINDOW_DISABLED := !!FileExist(IT_WINDOW_DISABLE_FLAG)
}

__InputTip_IsWindowDisabled() {
    global IT_WINDOW_DISABLED
    return IT_WINDOW_DISABLED
}
```

这里故意不把状态更新成“真正 Pause”。它只是一个轻量的逻辑门，不改变脚本生命周期。

## 主仓库改动二：包装快捷键绑定

同样在 `src/InputTip.ahk` 中，把热键绑定改为包装函数：

```ahk
if (hotkey_CN) {
    try {
        Hotkey(hotkey_CN, __InputTip_switch_CN)
    }
}
if (hotkey_EN) {
    try {
        Hotkey(hotkey_EN, __InputTip_switch_EN)
    }
}
if (hotkey_Caps) {
    try {
        Hotkey(hotkey_Caps, __InputTip_switch_Caps)
    }
}
if (hotkey_Pause) {
    try {
        Hotkey(hotkey_Pause, __InputTip_pauseApp)
    }
}
if (hotkey_ShowCode) {
    try {
        Hotkey(hotkey_ShowCode, __InputTip_showCode)
    }
}

__InputTip_switch_CN(*) {
    if (__InputTip_IsWindowDisabled()) {
        return
    }
    switch_CN()
}

__InputTip_switch_EN(*) {
    if (__InputTip_IsWindowDisabled()) {
        return
    }
    switch_EN()
}

__InputTip_switch_Caps(*) {
    if (__InputTip_IsWindowDisabled()) {
        return
    }
    switch_Caps()
}

__InputTip_pauseApp(*) {
    if (__InputTip_IsWindowDisabled()) {
        return
    }
    pauseApp()
}

__InputTip_showCode(*) {
    if (__InputTip_IsWindowDisabled()) {
        return
    }
    showCode()
}
```

这样只拦住“快捷键触发”的入口，不影响托盘菜单本身的已有行为。

## 主仓库改动三：保护符号与光标相关入口

在 `src/InputTip.ahk` 中补两处保护：

```ahk
needSkip(exe_str) {
    if (__InputTip_IsWindowDisabled()) {
        return 1
    }
    return !showCursorPos && InStr(modeList.JAB, exe_str)
}
```

```ahk
returnCanShowSymbol(&left, &top, &right, &bottom) {
    if (__InputTip_IsWindowDisabled()) {
        left := 0, top := 0, right := 0, bottom := 0
        return 0
    }

    res := 0
    try {
        res := GetCaretPosEx(&left, &top, &right, &bottom)
    } catch {
        left := 0, top := 0, right := 0, bottom := 0
        return 0
    }
}
```

## 主仓库改动四：拦住主循环里的自动切换

只改 `needSkip(...)` 还不够，因为自动切换输入法的逻辑在 `src/utils/show.ahk` 的主循环里。

在拿到当前前台窗口信息后，尽早插入：

```ahk
if (__InputTip_IsWindowDisabled()) {
    if (!lastWindowDisabled) {
        hideSymbol()
        if (changeCursor) {
            revertCursor(cursorInfo)
        }
        lastSymbol := ""
        lastCursor := ""
        lastWindow := ""
    }
    lastWindowDisabled := 1
    continue
}

if (lastWindowDisabled) {
    lastWindowDisabled := 0
    hasWindowChange := 1
}
```

这样才能保证：

- 不自动切换输入法
- 不显示符号提示
- 已加载的鼠标样式恢复
- 离开目标窗口后重新触发一次窗口变化逻辑，自动恢复正常行为

## 主仓库改动五：关闭实时状态 Tooltip

如果用户之前已经开启“显示实时的状态码和切换码”，进入禁用窗口后也应该停止显示。

在 `src/menu/tray-menu.ahk` 的 `showCode()` 定时器里加：

```ahk
if (__InputTip_IsWindowDisabled()) {
    ToolTip()
    return
}
```

## 实际效果

当焦点进入 `mstsc.exe`：

- 插件检测命中目标窗口
- 创建 `window_disable.flag`
- 主程序同步到 `IT_WINDOW_DISABLED = true`
- 主循环、符号显示、自动切换、相关热键开始主动跳过

表现为：

- 不自动切换输入法
- 不显示符号提示
- 不响应相关快捷键
- 进程仍然存在

当焦点离开 `mstsc.exe`：

- 插件删除 `window_disable.flag`
- 主程序同步到 `IT_WINDOW_DISABLED = false`
- InputTip 自动恢复正常工作

表现为无需手动重启，也无需手动恢复。

## 注意
暂时只支持插件，没有适配gui配置界面