### PR TITLE
fix: skip overlay refresh in JAB process

### DIFF
--- a/src/core/manifest.ahk
+++ b/src/core/manifest.ahk
@@ -44,11 +44,13 @@ WM_MOUSEWHEEL_Handler(wParam, lParam, msg, hwnd) {
 
 OnMessage(0x007E, OnDisplayChange)
 OnDisplayChange(wParam, lParam, msg, hwnd) {
-    SetTimer(() => (
-        var.screenNum := MonitorGetCount(),
-        var.screenList := getScreenInfo(),
+    SetTimer(updateScreenInfo, -500)
+}
+updateScreenInfo() {
+    var.screenNum := MonitorGetCount()
+    var.screenList := getScreenInfo()
+    if !isJAB
         updateOverlay()
-    ), -500)
 }
 
 hideOnTrayGui := []


### PR DESCRIPTION
## Summary
- 将显示器变化后的刷新逻辑拆到 `updateScreenInfo()`
- JAB 子进程只刷新屏幕信息，避免调用未加载的 `updateOverlay()`

## Testing
- 未运行 AHK 实机测试